### PR TITLE
put code back into LoginVC and added modal presentation

### DIFF
--- a/StorySquad/AppLifecycle/SceneDelegate.swift
+++ b/StorySquad/AppLifecycle/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = LoginVC()
+        window.rootViewController = MainTabbarVC()
         self.window = window
         window.makeKeyAndVisible()
     }

--- a/StorySquad/Login/LoginVC.swift
+++ b/StorySquad/Login/LoginVC.swift
@@ -110,23 +110,53 @@ class LoginVC: UIViewController {
       view.backgroundColor = UIColor.aquaColor
         
       configureUI()
+        
+        NotificationCenter.default.addObserver(forName: .oktaAuthenticationSuccessful, object: nil, queue: .main, using: checkForExistingProfile)
+            
+        NotificationCenter.default.addObserver(forName: .oktaAuthenticationExpired, object: nil, queue: .main, using: alertUserOfExpiredCredentials)
     }
    
    
    @objc func handleLoginButton() {
 //    Uncomment to access Okta Login Page
-      UIApplication.shared.open(ProfileController.shared.oktaAuth.identityAuthURL()!)
+//      UIApplication.shared.open(ProfileController.shared.oktaAuth.identityAuthURL()!)
 
       let modal = PinVC()
-      modal.modalPresentationStyle = .fullScreen
       present(modal, animated: true, completion: nil)
       print("tapped")
       
 //      let rootVC = MissionVC()
 //      navigationController?.pushViewController(rootVC, animated: true)
 //
-   }
-   
+   }//
+    
+    let profileController = ProfileController.shared
+    
+    private func checkForExistingProfile() {
+        profileController.checkForExistingAuthenticatedUserProfile { [weak self] (exists) in
+            
+            guard let self = self,
+                self.presentedViewController == nil else { return }
+            
+            if exists {
+                //segue to rootview
+               // self.navigationController?.popViewController(animated: true)
+            }
+        }
+    }//
+    
+    private func checkForExistingProfile(with notification: Notification) {
+        checkForExistingProfile()
+    }//
+    
+    private func alertUserOfExpiredCredentials(_ notification: Notification) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            self.presentSimpleAlert(with: "Your Okta credentials have expired",
+                           message: "Please sign in again",
+                           preferredStyle: .alert,
+                           dismissText: "Dimiss")
+        }
+    }//
    
    
    override var preferredStatusBarStyle: UIStatusBarStyle {

--- a/StorySquad/Mission/MainTabbarVC.swift
+++ b/StorySquad/Mission/MainTabbarVC.swift
@@ -9,6 +9,10 @@
 import UIKit
 
 class MainTabbarVC: UITabBarController {
+    
+    override func viewDidAppear(_ animated: Bool) {
+        showLoginVC()
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -30,9 +34,6 @@ class MainTabbarVC: UITabBarController {
       UINavigationBar.appearance().standardAppearance = coloredAppearance
       UINavigationBar.appearance().scrollEdgeAppearance = coloredAppearance
         
-    NotificationCenter.default.addObserver(forName: .oktaAuthenticationSuccessful, object: nil, queue: .main, using: checkForExistingProfile)
-        
-    NotificationCenter.default.addObserver(forName: .oktaAuthenticationExpired, object: nil, queue: .main, using: alertUserOfExpiredCredentials)
 
         createTabbar()
     }//
@@ -89,36 +90,11 @@ class MainTabbarVC: UITabBarController {
    func configureNavigationBar() {
        UINavigationBar.appearance().tintColor = .label
    }
-
     
-    let profileController = ProfileController.shared
-    
-    private func checkForExistingProfile() {
-        profileController.checkForExistingAuthenticatedUserProfile { [weak self] (exists) in
-            
-            guard let self = self,
-                self.presentedViewController == nil else { return }
-            
-            if exists {
-                //segue to rootview
-               // self.navigationController?.popViewController(animated: true)
-            }
-        }
+    private func showLoginVC() {
+        let modal = LoginVC()
+        present(modal, animated: true, completion: nil)
+        print("tapped")
     }//
-    
-    private func checkForExistingProfile(with notification: Notification) {
-        checkForExistingProfile()
-    }
-    
-    private func alertUserOfExpiredCredentials(_ notification: Notification) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            self.presentSimpleAlert(with: "Your Okta credentials have expired",
-                           message: "Please sign in again",
-                           preferredStyle: .alert,
-                           dismissText: "Dimiss")
-        }
-    }
-    
-    
     
 }// Tabbar


### PR DESCRIPTION
@kennethjones1991 I had to move the code back to the LoginVC because that is going to be presented modally and then the code will perform. I changed the scene delegate to load the main tab bar and then when view appears to show the Login screen. Right now users cannot log in because the profile controller is failing when calling to the back end. Please review the profile controller and core data model. Once that is working the login screen will segue to the root view. 